### PR TITLE
Added:  Service Detection and Banner Grabbing Feature

### DIFF
--- a/ScanSpectre/ScanSpectre.Designer.cs
+++ b/ScanSpectre/ScanSpectre.Designer.cs
@@ -101,11 +101,13 @@
             // dataGridView1
             this.dataGridView1.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.dataGridView1.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
-            new System.Windows.Forms.DataGridViewTextBoxColumn() { Name = "Port", HeaderText = "Port", Width = 75 },
-            new System.Windows.Forms.DataGridViewTextBoxColumn() { Name = "Status", HeaderText = "Status", Width = 150 }});
+                new System.Windows.Forms.DataGridViewTextBoxColumn() { Name = "Port", HeaderText = "Port", Width = 75 },
+                new System.Windows.Forms.DataGridViewTextBoxColumn() { Name = "Status", HeaderText = "Status", Width = 75 },
+                new System.Windows.Forms.DataGridViewTextBoxColumn() { Name = "Service", HeaderText = "Service/Banner", Width = 200 }
+            });
             this.dataGridView1.Location = new System.Drawing.Point(15, 250);
             this.dataGridView1.Name = "dataGridView1";
-            this.dataGridView1.Size = new System.Drawing.Size(245, 200);
+            this.dataGridView1.Size = new System.Drawing.Size(400, 200);
             this.dataGridView1.TabIndex = 6;
 
             // lblIp
@@ -167,7 +169,7 @@
             this.grpSettings.Text = "Scan Settings";
 
             // ScanSpectre (Main Form)
-            this.ClientSize = new System.Drawing.Size(300, 480);
+            this.ClientSize = new System.Drawing.Size(450, 500);
             this.Controls.Add(this.grpSettings);
             this.Controls.Add(this.btnStartScan);
             this.Controls.Add(this.dataGridView1);

--- a/ScanSpectre/ScanSpectre.cs
+++ b/ScanSpectre/ScanSpectre.cs
@@ -1,10 +1,5 @@
 ﻿using System;
-using System.Net;
-using System.Net.Sockets;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
-using System.Collections.Concurrent;
 
 namespace ScanSpectre
 {
@@ -13,6 +8,24 @@ namespace ScanSpectre
         public ScanSpectre()
         {
             InitializeComponent();
+            txtIp.GotFocus += RemoveText;
+            txtIp.LostFocus += AddText;
+        }
+
+        private void RemoveText(object sender, EventArgs e)
+        {
+            if (txtIp.Text == "Enter IP/Domain")
+            {
+                txtIp.Text = "";
+            }
+        }
+
+        private void AddText(object sender, EventArgs e)
+        {
+            if (string.IsNullOrWhiteSpace(txtIp.Text))
+            {
+                txtIp.Text = "Enter IP/Domain";
+            }
         }
 
         private void btnStartScan_Click(object sender, EventArgs e)
@@ -22,9 +35,9 @@ namespace ScanSpectre
 
             AddressScanner scanner = new AddressScanner(
                 txtIp.Text,
-                int.Parse(txtStartPort.Text),
-                int.Parse(txtEndPort.Text),
-                int.Parse(txtTimeout.Text),
+                (int)txtStartPort.Value,
+                (int)txtEndPort.Value,
+                (int)txtTimeout.Value,
                 dataGridView1,
                 txtCurrentPort,
                 this,


### PR DESCRIPTION
- IP Address or Domain Scanning

  - Scan any IP address or domain name to detect open ports.
 
- Configurable Port Range

  - Specify a start and end port to define your scan range.
- Connection Timeout Control

  - Adjust how long each connection attempt lasts to control the speed and depth of the scan.
- Service Detection & Banner Grabbing

  - Capture basic service information from open ports (similar to Zenmap/Nmap). Detects HTTP, FTP, SSH, and more.
- User-Friendly GUI

  - Intuitive, easy-to-use interface that displays scan progress and results in real-time.